### PR TITLE
Allow initialization with explicit nil values

### DIFF
--- a/lib/ruby_gntp.rb
+++ b/lib/ruby_gntp.rb
@@ -131,10 +131,9 @@ class GNTP
   # instant notification
   #
   def self.notify(params, &callback)
-    host    = params[:host]
-    passwd  = params[:passwd]
+    gntp_args = [params[:app_name], params[:host], params[:passwd]].compact
 
-    growl = GNTP.new(params[:app_name], host, passwd)
+    growl = GNTP.new(*gntp_args)
 
     notification = params
     notification[:name] = params[:app_name] || "Ruby/GNTP notification"


### PR DESCRIPTION
The `g` gem is using `ruby_gntp` with explicit `host`/`passwd` params, so the `GNTP.notify` class methods is instanciating an object with `nil` values for both parameters, which makes Ruby's `Resolv.create` method raising an error : https://github.com/ruby/ruby/blob/ruby_2_0_0/lib/resolv.rb#L1169-L1178

By not giving null values to GNTP, it's using its default values.
