### PR TITLE
Add "lib" to the load path

### DIFF
--- a/ruby_gntp.gemspec
+++ b/ruby_gntp.gemspec
@@ -1,4 +1,5 @@
-require 'lib/ruby_gntp'
+$:.push File.expand_path("../lib", __FILE__)
+require 'ruby_gntp'
 
 Gem::Specification.new do |s|
   s.name = GNTP::RUBY_GNTP_NAME


### PR DESCRIPTION
The current directory has been removed from the load path
in Ruby 1.9, so let's push the "lib" directory at the end of it.
