### PR TITLE
Read icon data in binary mode.

### DIFF
--- a/lib/ruby_gntp.rb
+++ b/lib/ruby_gntp.rb
@@ -268,7 +268,7 @@ class GNTP
   #
   def handle_icon(icon, type)
     if File.exists?(icon) && @target_host != 'localhost'
-      file = File.new(icon)
+      file = File.new(icon, 'rb')
       data = file.read
       size = data.length
       if size > 0


### PR DESCRIPTION
On Windows platform, File#read cannot read data beyond the 0x1A (treated
as EOF) character from a file which is opened in text mode.
